### PR TITLE
fix: add v prefix to tarball download URL in version script

### DIFF
--- a/scripts/update-version.pl
+++ b/scripts/update-version.pl
@@ -1,12 +1,13 @@
 #!/usr/bin/env -S perl -pi
 BEGIN {
     exit if scalar @ARGV == 0;
-    $version =
+    my $tag =
 `curl -s https://api.github.com/repos/xmake-io/xmake/releases/latest | jq -r .tag_name`;
-    chomp $version;
+    chomp $tag;
+    $version = $tag;
     $version =~ s/^v//;
     $sha =
-`curl -sL https://github.com/xmake-io/xmake/releases/download/$version/xmake-$version.tar.gz | sha256sum`;
+`curl -sL https://github.com/xmake-io/xmake/releases/download/$tag/xmake-$tag.tar.gz | sha256sum`;
     chomp $sha;
     $sha =~ s/\s*-//;
 }


### PR DESCRIPTION
## Problem

The xrepo package checksum has been wrong since commit [`dc41821d`](https://github.com/xmake-io/xmake-wheel/commit/dc41821d) (Jan 11, 2025), which added `$version =~ s/^v//` to strip the `v` prefix for `package.json`/`pyproject.toml`.

This also stripped it from the tarball download URL, which needs the `v` in both the tag and filename:

```diff
- https://github.com/xmake-io/xmake/releases/download/3.0.7/xmake-3.0.7.tar.gz    # 404
+ https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-v3.0.7.tar.gz  # 200
```

The 404 response gets piped to `sha256sum`, producing `0019dfc4...` — which is the SHA256 of GitHub's 404 HTML page. This hash has been written to `xmake.lua` on every weekly run since July 2025:

| Commit | Date | Version change | Hash |
|--------|------|---------------|------|
| [`c09e6c84`](https://github.com/xmake-io/xmake-wheel/commit/c09e6c84) | Jun 20 | v3.0.0 → v3.0.0 | `e749c2a9...` → **`0019dfc4...`** (first 404 hash) |
| [`a9374f0e`](https://github.com/xmake-io/xmake-wheel/commit/a9374f0e) | Jul 18 | v3.0.0 → v3.0.1 | `0019dfc4...` (unchanged) |
| ... every subsequent commit ... | | v3.0.x → v3.0.y | `0019dfc4...` (unchanged) |

This causes `build-wheels-and-test` CI to fail with `unmatched checksum, current hash(c9052e45) != original hash(0019dfc4)`.

## Fix

Preserve the original tag (with `v` prefix) in a `$tag` variable for the download URL, while keeping the stripped version for `package.json`/`pyproject.toml`.

## CI status on this PR

The `build-wheels-and-test` jobs will still fail on this PR because the manifest (`packages/x/xmake/xmake.lua`) still contains the stale `0019dfc4` hash. This PR only fixes the script that generates the hash — not the hash itself.

**After merge**, either:
- The next weekly `version.yml` run (Friday 18:00 UTC) will update the manifest with the correct hash
- Or run `version.yml` manually via `workflow_dispatch` to fix it immediately